### PR TITLE
Fix duplicate publish triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
       - 'v*'
   pull_request:
     branches: [ main, master ]
-  release:
-    types: [ published ]
 
 jobs:
   test:
@@ -44,44 +42,8 @@ jobs:
     - name: Check build output
       run: ls -la dist/
 
-  publish-on-release:
-    if: github.event_name == 'release' && github.event.action == 'published'
-    needs: test
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 10.12.3
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
-        cache: 'pnpm'
-        registry-url: 'https://registry.npmjs.org'
-    
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-    
-    - name: Build project
-      run: pnpm build
-    
-    - name: Run tests (if any)
-      run: pnpm test --if-present
-    
-    - name: Publish to npm
-      run: |
-        npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
-        npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  publish-on-tag:
+  publish:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: test
     runs-on: ubuntu-latest
@@ -117,3 +79,10 @@ jobs:
         npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Publish to GitHub Packages
+      run: |
+        npm config set //npm.pkg.github.com/:_authToken $NODE_AUTH_TOKEN
+        npm publish --access public --registry https://npm.pkg.github.com
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- remove release event from CI to only publish on tags
- combine to a single `publish` job
- publish to both npm and GitHub Packages in one job

## Testing
- `pnpm install` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685c10459b84832cb0e431c120cf8944