### PR TITLE
Update package name and publish configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@oriolrius:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "n8n-nodes-notion-upload-media",
+  "name": "@oriolrius/n8n-nodes-notion-upload-media",
   "version": "1.0.3",
   "description": "n8n node for uploading media files to Notion blocks",
   "keywords": [
@@ -32,6 +32,9 @@
     "pnpm": ">=9.1"
   },
   "packageManager": "pnpm@10.12.3",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "main": "index.js",
   "scripts": {
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
## Summary
- rename the package to `@oriolrius/n8n-nodes-notion-upload-media`
- add npm publish configuration for GitHub registry
- include `.npmrc` for publishing to GitHub Packages

## Testing
- `pnpm lint` *(fails: unable to download packages)*
- `pnpm build` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_685c10618fe4832c863e232641ecd7a3